### PR TITLE
Landing page should be on login

### DIFF
--- a/split-webapp/split/src/App.js
+++ b/split-webapp/split/src/App.js
@@ -10,7 +10,7 @@ function App() {
       <div className="App">
         <header className="App-header">
         <div>
-          <Route path="/login" component={Login}/>
+          <Route exact path="/" component={Login}/>
           <Route path="/home" component={Home}/>
         </div>
         </header>

--- a/split-webapp/split/src/pages/Home.js
+++ b/split-webapp/split/src/pages/Home.js
@@ -10,7 +10,7 @@ function Home() {
     <div>
       <div className="Sidebar">
         <h1>Sp/it Home</h1>
-        <NavLink to="/login"><button>Sign Out</button></NavLink>
+        <NavLink to="/"><button>Sign Out</button></NavLink>
         <ul className="">
           <li><NavLink to="/home/transactions">Transactions</NavLink></li>
           <li><NavLink to="/home/split">Split</NavLink></li>

--- a/split-webapp/split/src/pages/Login.js
+++ b/split-webapp/split/src/pages/Login.js
@@ -7,7 +7,7 @@ function Login() {
         <header className="App-header">
         <h1>Sp/it Login</h1>
         <ul className="App-header">
-        <NavLink to="/home"><button>To Home</button></NavLink>
+        <NavLink to="/home/transactions"><button>To Home</button></NavLink>
         </ul>
         </header>
       </div>


### PR DESCRIPTION
Closes #48 

**Description**
Login page is now acting as the landing page, and the home page will always land on transactions (not just blank home page)

**Testing**
Checked that navigation works from all buttons and that `npm start` shows the login page automatically.

**Checklist**
<!-- this section may be replaced with GitHub action checks later -->
- [x] I have tested my change
- [x] Code builds successfully and all tests pass
- [x] Docs have been added/updated if needed
