### PR TITLE
Frontend build check

### DIFF
--- a/.github/workflows/webapp-test.yml
+++ b/.github/workflows/webapp-test.yml
@@ -28,7 +28,12 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm ci
+      - name: Install dependencies
+        run: npm ci
         working-directory: ${{env.working-directory}}
-      - run: npm run build
+      - name: Build
+        run: npm run build
+        working-directory: ${{env.working-directory}}
+      - name: Lint
+        run: npm run lint
         working-directory: ${{env.working-directory}}

--- a/.github/workflows/webapp-test.yml
+++ b/.github/workflows/webapp-test.yml
@@ -32,7 +32,3 @@ jobs:
         working-directory: ${{env.working-directory}}
       - run: npm run build
         working-directory: ${{env.working-directory}}
-      - run: npm test
-        working-directory: ${{env.working-directory}}
-        env:
-          CI: true

--- a/.github/workflows/webapp-test.yml
+++ b/.github/workflows/webapp-test.yml
@@ -15,6 +15,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      working-directory: ./split-webapp/split
 
     strategy:
       matrix:
@@ -26,9 +28,11 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - run: cd split-webapp/split
       - run: npm ci
-      - run: npm run build --if-present
+        working-directory: ${{env.working-directory}}
+      - run: npm run build
+        working-directory: ${{env.working-directory}}
       - run: npm test
+        working-directory: ${{env.working-directory}}
         env:
           CI: true

--- a/.github/workflows/webapp-test.yml
+++ b/.github/workflows/webapp-test.yml
@@ -1,0 +1,34 @@
+# This workflow will do a clean install of node dependencies, build the source code and run the test npm-script. This will ensure
+#   that the webapp builds and renders without errors
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Webapp build check
+
+on:
+  push:
+    branches: [master]
+    paths: split-webapp/*
+  pull_request:
+    branches: [master]
+    paths: split-webapp/*
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: cd split-webapp/split
+      - run: npm ci
+      - run: npm run build --if-present
+      - run: npm test
+        env:
+          CI: true

--- a/.github/workflows/webapp-test.yml
+++ b/.github/workflows/webapp-test.yml
@@ -7,10 +7,10 @@ name: Webapp build check
 on:
   push:
     branches: [master]
-    paths: split-webapp/*
+    paths: split-webapp/**/*
   pull_request:
     branches: [master]
-    paths: split-webapp/*
+    paths: split-webapp/**/*
 
 jobs:
   build:


### PR DESCRIPTION
Closes #45 

**Description**

Sets up a workflow (modified version of the default NodeJS workflow) that ensures the frontend builds.

`split-webapp/split/package-lock.json` has been updated so that the `npm ci` step works (installs dependencies directly from `package-lock.json`)

**Testing**

I have setup this workflow on my fork's master and made a dummy PR that changes frontend files
[see the workflow in action here](https://github.com/margeobur/A1/pull/3/checks)

**Checklist**
<!-- this section may be replaced with GitHub action checks later -->
- [x] I have tested my change
- [x] Code builds successfully and all tests pass
- [x] Docs have been added/updated if needed
