### PR TITLE
Added get_bills endpoint, moved unit tests out of src module

### DIFF
--- a/server/src/api/bill_data.py
+++ b/server/src/api/bill_data.py
@@ -1,8 +1,6 @@
 import cherrypy
 import urllib.request
 import json
-import base64
-import socket
 
 """
     Json receiving example:
@@ -23,23 +21,53 @@ class BillDataApi(object):
         self.database = database
 
     @cherrypy.expose
-    def list_bills(self):
+    def get_bills(self):
         """Searches database for all bills
             does not modify database
             Check database structure doc
             
-        Arguments:
-            json -- check api doc for json format
+        JSON Arguments:
+            None
+        JSON Returns:
+            bills -- list of bill JSONs
+            message (optional) -- error message if applicable
         """
-        return "4"
-    
-    @cherrypy.expose
-    def get_bill(self):
-        """Searches database for transaction info on specific transaction id
-            does not modify database
-            Check database structure doc
         
-        Arguments:
-            json -- check api doc for json format
-        """
-        pass
+        bills = []
+        error_msg = ""
+        try:
+            username = cherrypy.session["username"]
+            bill_objects = self.database.get_bills_from_username(username)
+            #converts internal object representation to appropriate json format
+            for bill_obj in bill_objects:
+                payment_objects = bill_obj.payments
+                payments = []
+                for payment_obj in payment_objects:
+                    payment_dict = {
+                        "payment_id" : payment_obj.payment_id,
+                        "to" : bill_obj.payer,
+                        "from" : payment_obj.payee_name,
+                        "amount" : payment_obj.amount_owed,
+                        "is_paid" : payment_obj.is_paid
+                    }
+                    payments.append(payment_dict)
+
+                bill_dict = {
+                    "bill_id" : bill_obj.bill_id,
+                    "timestamp" : bill_obj.timestamp,
+                    "title" : bill_obj.title,
+                    "total" : bill_obj.total,
+                    "payments" : payments
+                }
+                bills.append(bill_dict)
+        except KeyError as e:
+            error_msg = "User not logged in"
+        except Exception as e:
+            print(e)
+            error_msg = "Unknown error occured"
+        finally:
+            response = {
+                'bills' : bills,
+                'message' : error_msg
+            }
+            return json.dumps(response)

--- a/server/src/db_manager.py
+++ b/server/src/db_manager.py
@@ -322,6 +322,6 @@ class DatabaseManager(object):
     def create_test_data(self):
         if self.add_user("Bob", "password"):
             self.add_user("Bil", "password")
-            payment2 = Payment("Jim", 45.98, False, 0)
-            payment3 = Payment("Tom", 10.00, False, 0)
-            self.add_bill("Bob", "Bob", "maccas", 105.98, [payment1, payment2, payment3])
+            payment1 = Payment("Jim", 45.98, False, 0)
+            payment2 = Payment("Tom", 10.00, False, 0)
+            self.add_bill("Bob", "Bob", "maccas", 105.98, [payment1, payment2])

--- a/server/test_db.py
+++ b/server/test_db.py
@@ -1,6 +1,6 @@
 import unittest
 import logging
-from db_manager import *
+from src.db_manager import *
 
 class TestDatabaseMethods(unittest.TestCase):
     def test_add_user(self):    


### PR DESCRIPTION
Closes #26

**Description**
Implemented the endpoint get_bills, which returns all of the bills belonging to that user account per the format in the API documentation page. If not logged in, returns an error message.

Also, I moved the test_db.py file from the /src/ to the base server directory. Ideally I wanted this in another parallel folder called /tests/, but after much effort I couldn't work out how to do parallel includes in python.

**Testing**
Tested using the Postman environment from the wiki. Successfully returns bills when called if logged in.

**Checklist**
<!-- this section may be replaced with GitHub action checks later -->
- [x] I have tested my change
- [x] Code builds successfully and all tests pass
- [ ] Docs have been added/updated if needed
