### PR TITLE
Moved linting and build order around

### DIFF
--- a/.github/workflows/webapp-test.yml
+++ b/.github/workflows/webapp-test.yml
@@ -31,9 +31,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
         working-directory: ${{env.working-directory}}
-      - name: Build
-        run: npm run build
-        working-directory: ${{env.working-directory}}
       - name: Lint
         run: npm run lint
+        working-directory: ${{env.working-directory}}
+      - name: Build
+        run: npm run build
         working-directory: ${{env.working-directory}}


### PR DESCRIPTION
Closes #78 

**Description**

The frontend build workflow was failing because the linting step came after building, so it was attempting to lint minified JS. (my bad)

Solution: swap the step order

**Testing**

I have made the change to the workflow on my fork and made a test PR [here](https://github.com/margeobur/A1/pull/5)

**Checklist**
<!-- this section may be replaced with GitHub action checks later -->
- [x] I have tested my change
- [x] Code builds successfully and all tests pass
- [x] Docs have been added/updated if needed
