### PR TITLE
Implemented payment API call to checkboxes + Styling of Transactions

### DIFF
--- a/split-webapp/split/src/App.css
+++ b/split-webapp/split/src/App.css
@@ -263,10 +263,17 @@
 .BillSummary {
   display: flex !important;
   justify-content: space-between !important;
-  justify-items: flex-start; 
+  justify-items: flex-start;
   flex-direction: row;
   align-items: flex-start !important;
   width: 100%;
   padding: 10px;
   padding-right: 38xpx;
+}
+
+.NoTransactions {
+  display: flex;
+  justify-content: center;
+  font-size: 13px;
+  padding: 10px;
 }

--- a/split-webapp/split/src/App.css
+++ b/split-webapp/split/src/App.css
@@ -216,3 +216,57 @@
   font-size: 20px;
   color: #e071ae;
 }
+
+.Bills {
+  box-shadow: none !important;
+  outline: none;
+  background: none !important;
+}
+
+.Payments {
+  flex-direction: column;
+  align-items: flex-start;
+  border-top-width: 0.3px;
+  border-top-style: solid;
+  justify-content: space-evenly;
+}
+
+.PaymentsTitle {
+  padding: 10px 0 5px 0;
+  flex-direction: row;
+  display: flex;
+  width: 100%;
+  justify-content: flex-start;
+}
+
+.PaymentHeaders {
+  margin-left: -2px;
+  size: 8px;
+  color: #3e8ef6;
+}
+
+.BillTitle {
+  display: flex;
+  font-size: 20px;
+  font-variant-caps: petite-caps;
+  align-self: flex-start;
+}
+
+.BillAmount {
+  display: flex;
+  font-size: 20px;
+  font-weight: 600;
+  justify-content: flex-end;
+  align-content: flex-end;
+}
+
+.BillSummary {
+  display: flex !important;
+  justify-content: space-between !important;
+  justify-items: flex-start; 
+  flex-direction: row;
+  align-items: flex-start !important;
+  width: 100%;
+  padding: 10px;
+  padding-right: 38xpx;
+}

--- a/split-webapp/split/src/components/TransactionList.js
+++ b/split-webapp/split/src/components/TransactionList.js
@@ -18,87 +18,6 @@ class TransactionList extends React.Component {
     };
   }
 
-
-populateBills(bills) {
-  if (bills.length === 0) {
-    return;
-  } else {
-
-    console.log(bills);
-  return bills.map(bill => (
-    <ExpansionPanel className="Bills">
-      <ExpansionPanelSummary>
-      <div className="BillSummary">
-        <div className="BillTitle">
-          {bill.title}
-        </div>
-        <div className="BillAmount">
-          ${bill.total}
-        </div>
-        </div>
-      </ExpansionPanelSummary>
-      <ExpansionPanelDetails className="Payments">
-      <div className="PaymentsTitle">
-      <PaymentIcon className="PaymentHeaders"/>
-      </div>
-        {bill.payments.map(payment => {
-          const label = `${payment.from} owes ${payment.to} $${payment.amount}`;
-          return (
-            <div key={payment.id}>
-              <FormControlLabel
-                aria-label="Acknowledge"
-                onClick={() => this.markPaid({
-                  payment_id: payment.payment_id,
-                  is_paid: !payment.is_paid,
-                })}
-                onFocus={event => event.stopPropagation()}
-                control={<Checkbox checked={payment.is_paid} />}
-                label={label}
-              />
-            </div>
-          );
-        })}
-      </ExpansionPanelDetails>
-    </ExpansionPanel>
-  ));
-      }
-}
-
-setPaidStatus(paymentId, paid) {
-  this.setState({
-    bills: this.state.bills.map((bill) => {
-      return {
-        ...bill,
-        payments: bill.payments.map((payment) => { 
-        if (payment.payment_id === paymentId) {
-          return { 
-            ...payment,
-            is_paid: paid,
-          }
-        }
-        return payment;
-      }) }
-      
-    })
-  });
-}
-
-markPaid(data) {
-  fetch("/api/pay_exec/make_payment", {
-    method: "POST",
-    body: JSON.stringify(data),
-    headers: {
-      "Content-Type": "application/json"
-    }
-  })
-    .then(res => {
-      // If "this" is not called in the createBill method, you may have to create the function outside of the class (es-lint rule)
-      this.setPaidStatus(data.payment_id, data.is_paid);
-      return res;
-    })
-    .catch(err => console.log(err));
-}
-
   componentDidMount() {
     //  actual address http://0.0.0.0:1234/api/bill_data/get_bill
     fetch("/api/bill_data/get_bills") // temp
@@ -117,13 +36,82 @@ markPaid(data) {
       });
   }
 
+  setPaidStatus(paymentId, paid) {
+    const { bills } = this.state;
+    this.setState({
+      bills: bills.map(bill => {
+        return {
+          ...bill,
+          payments: bill.payments.map(payment => {
+            if (payment.payment_id === paymentId) {
+              return {
+                ...payment,
+                is_paid: paid
+              };
+            }
+            return payment;
+          })
+        };
+      })
+    });
+  }
+
+  populateBills(bills) {
+    return bills.map(bill => (
+      <ExpansionPanel className="Bills">
+        <ExpansionPanelSummary>
+          <div className="BillSummary">
+            <div className="BillTitle">{bill.title}</div>
+            <div className="BillAmount">${bill.total}</div>
+          </div>
+        </ExpansionPanelSummary>
+        <ExpansionPanelDetails className="Payments">
+          <div className="PaymentsTitle">
+            <PaymentIcon className="PaymentHeaders" />
+          </div>
+          {bill.payments.map(payment => {
+            const label = `${payment.from} owes ${payment.to} $${payment.amount}`;
+            return (
+              <div key={payment.id}>
+                <FormControlLabel
+                  aria-label="Acknowledge"
+                  onClick={() =>
+                    this.markPaid({
+                      payment_id: payment.payment_id,
+                      is_paid: !payment.is_paid
+                    })
+                  }
+                  onFocus={event => event.stopPropagation()}
+                  control={<Checkbox checked={payment.is_paid} />}
+                  label={label}
+                />
+              </div>
+            );
+          })}
+        </ExpansionPanelDetails>
+      </ExpansionPanel>
+    ));
+  }
+
+  markPaid(data) {
+    fetch("/api/pay_exec/make_payment", {
+      method: "POST",
+      body: JSON.stringify(data),
+      headers: {
+        "Content-Type": "application/json"
+      }
+    })
+      .then(res => {
+        // If "this" is not called in the createBill method, you may have to create the function outside of the class (es-lint rule)
+        this.setPaidStatus(data.payment_id, data.is_paid);
+        return res;
+      })
+      .catch(err => console.log(err));
+  }
+
   render() {
     const { bills } = this.state;
-    return (
-      <div>
-        {this.populateBills(bills)}
-      </div>
-    );
+    return <div>{this.populateBills(bills)} </div>;
   }
 }
 

--- a/split-webapp/split/src/components/TransactionList.js
+++ b/split-webapp/split/src/components/TransactionList.js
@@ -1,26 +1,13 @@
 import React from "react";
 import {
-  List,
-  ListItem,
-  ListItemIcon,
-  ListItemText,
-  Divider,
   ExpansionPanel,
   ExpansionPanelSummary,
   ExpansionPanelDetails,
-  Typography,
   Checkbox,
   FormControlLabel
 } from "@material-ui/core";
 import PaymentIcon from "@material-ui/icons/Payment";
 import "../App.css";
-
-function ListItemLink(props) {
-  // Creates an error due to props spreading
-  // eslint-disable-next-line react/jsx-props-no-spreading
-  return <ListItem button component="a" {...props} />;
-}
-
 
 class TransactionList extends React.Component {
   constructor(props) {
@@ -39,13 +26,21 @@ populateBills(bills) {
 
     console.log(bills);
   return bills.map(bill => (
-    <ExpansionPanel>
+    <ExpansionPanel className="Bills">
       <ExpansionPanelSummary>
-        <Typography variant="h5">
-          {bill.title}, ${bill.total}
-        </Typography>
+      <div className="BillSummary">
+        <div className="BillTitle">
+          {bill.title}
+        </div>
+        <div className="BillAmount">
+          ${bill.total}
+        </div>
+        </div>
       </ExpansionPanelSummary>
-      <ExpansionPanelDetails>
+      <ExpansionPanelDetails className="Payments">
+      <div className="PaymentsTitle">
+      <PaymentIcon className="PaymentHeaders"/>
+      </div>
         {bill.payments.map(payment => {
           const label = `${payment.from} owes ${payment.to} $${payment.amount}`;
           return (
@@ -127,44 +122,6 @@ markPaid(data) {
     return (
       <div>
         {this.populateBills(bills)}
-        <List component="nav" aria-label="main mailbox folders">
-          <Divider />
-          <ListItem button>
-            <ListItemLink href="#simple-list" className="TransactionSummary">
-              <ListItemText primary="Ryan owes Vanessa $10" />
-              <ListItemIcon>
-                <PaymentIcon className="PaymentIcon" />
-              </ListItemIcon>
-            </ListItemLink>
-          </ListItem>
-          <Divider />
-          <ListItem button>
-            <ListItemLink href="#simple-list" className="TransactionSummary">
-              <ListItemText primary="Vanessa owes sean $4" />
-              <ListItemIcon>
-                <PaymentIcon className="PaymentIcon" />
-              </ListItemIcon>
-            </ListItemLink>
-          </ListItem>
-          <Divider />
-          <ListItem button>
-            <ListItemLink href="#simple-list" className="TransactionSummary">
-              <ListItemText primary="Ryan owes Vanessa a cat" />
-              <ListItemIcon>
-                <PaymentIcon className="PaymentIcon" />
-              </ListItemIcon>
-            </ListItemLink>
-          </ListItem>
-          <Divider />
-          <ListItem button>
-            <ListItemLink href="#simple-list" className="TransactionSummary">
-              <ListItemText primary="Sean owes Ryan an apology" />
-              <ListItemIcon>
-                <PaymentIcon className="PaymentIcon" />
-              </ListItemIcon>
-            </ListItemLink>
-          </ListItem>
-        </List>
       </div>
     );
   }

--- a/split-webapp/split/src/components/TransactionList.js
+++ b/split-webapp/split/src/components/TransactionList.js
@@ -25,7 +25,6 @@ class TransactionList extends React.Component {
         return res.json();
       })
       .then(data => {
-        console.log(data.bills);
         // make a mapping of bills to list items here and render it below
         this.setState({
           bills: data.bills
@@ -57,7 +56,7 @@ class TransactionList extends React.Component {
   }
 
   populateBills(bills) {
-    return bills.map(bill => (
+    const transaction = bills.map(bill => (
       <ExpansionPanel className="Bills">
         <ExpansionPanelSummary>
           <div className="BillSummary">
@@ -91,6 +90,15 @@ class TransactionList extends React.Component {
         </ExpansionPanelDetails>
       </ExpansionPanel>
     ));
+
+    if (transaction.length === 0) {
+      return (
+        <div className="NoTransactions">
+          You have no outstanding transactions.
+        </div>
+      );
+    }
+    return transaction;
   }
 
   markPaid(data) {
@@ -102,7 +110,6 @@ class TransactionList extends React.Component {
       }
     })
       .then(res => {
-        // If "this" is not called in the createBill method, you may have to create the function outside of the class (es-lint rule)
         this.setPaidStatus(data.payment_id, data.is_paid);
         return res;
       })

--- a/split-webapp/split/src/components/TransactionList.js
+++ b/split-webapp/split/src/components/TransactionList.js
@@ -21,7 +21,18 @@ function ListItemLink(props) {
   return <ListItem button component="a" {...props} />;
 }
 
-function populateBills(bills) {
+
+class TransactionList extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      bills: []
+    };
+  }
+
+
+populateBills(bills) {
   return bills.map(bill => (
     <ExpansionPanel>
       <ExpansionPanelSummary>
@@ -36,7 +47,7 @@ function populateBills(bills) {
             <div key={payment.id}>
               <FormControlLabel
                 aria-label="Acknowledge"
-                onClick={() => markPaid({
+                onClick={() => this.markPaid({
                   payment_id: payment.id,
                   is_paid: !payment.is_paid,
                 })}
@@ -52,7 +63,7 @@ function populateBills(bills) {
   ));
 }
 
-function markPaid(data) {
+markPaid(data) {
   fetch("/api/bill_exec/make_payment", {
     method: "POST",
     body: JSON.stringify(data),
@@ -67,15 +78,6 @@ function markPaid(data) {
     })
     .catch(err => console.log(err));
 }
-
-class TransactionList extends React.Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      bills: []
-    };
-  }
 
   componentDidMount() {
     //  actual address http://0.0.0.0:1234/api/bill_data/get_bill
@@ -98,7 +100,7 @@ class TransactionList extends React.Component {
     const { bills } = this.state;
     return (
       <div>
-        {populateBills(bills)}
+        {this.populateBills(bills)}
         <List component="nav" aria-label="main mailbox folders">
           <Divider />
           <ListItem button>

--- a/split-webapp/split/src/components/TransactionList.js
+++ b/split-webapp/split/src/components/TransactionList.js
@@ -36,7 +36,10 @@ function populateBills(bills) {
             <div key={payment.id}>
               <FormControlLabel
                 aria-label="Acknowledge"
-                onClick={event => event.stopPropagation()}
+                onClick={() => markPaid({
+                  payment_id: payment.id,
+                  is_paid: !payment.is_paid,
+                })}
                 onFocus={event => event.stopPropagation()}
                 control={<Checkbox checked={payment.is_paid} />}
                 label={label}
@@ -47,6 +50,22 @@ function populateBills(bills) {
       </ExpansionPanelDetails>
     </ExpansionPanel>
   ));
+}
+
+function markPaid(data) {
+  fetch("/api/bill_exec/make_payment", {
+    method: "POST",
+    body: JSON.stringify(data),
+    headers: {
+      "Content-Type": "application/json"
+    }
+  })
+    .then(res => {
+      // If "this" is not called in the createBill method, you may have to create the function outside of the class (es-lint rule)
+      this.setState({});
+      return res;
+    })
+    .catch(err => console.log(err));
 }
 
 class TransactionList extends React.Component {

--- a/split-webapp/split/src/components/TransactionList.js
+++ b/split-webapp/split/src/components/TransactionList.js
@@ -33,6 +33,11 @@ class TransactionList extends React.Component {
 
 
 populateBills(bills) {
+  if (bills.length === 0) {
+    return;
+  } else {
+
+    console.log(bills);
   return bills.map(bill => (
     <ExpansionPanel>
       <ExpansionPanelSummary>
@@ -48,7 +53,7 @@ populateBills(bills) {
               <FormControlLabel
                 aria-label="Acknowledge"
                 onClick={() => this.markPaid({
-                  payment_id: payment.id,
+                  payment_id: payment.payment_id,
                   is_paid: !payment.is_paid,
                 })}
                 onFocus={event => event.stopPropagation()}
@@ -61,10 +66,30 @@ populateBills(bills) {
       </ExpansionPanelDetails>
     </ExpansionPanel>
   ));
+      }
+}
+
+setPaidStatus(paymentId, paid) {
+  this.setState({
+    bills: this.state.bills.map((bill) => {
+      return {
+        ...bill,
+        payments: bill.payments.map((payment) => { 
+        if (payment.payment_id === paymentId) {
+          return { 
+            ...payment,
+            is_paid: paid,
+          }
+        }
+        return payment;
+      }) }
+      
+    })
+  });
 }
 
 markPaid(data) {
-  fetch("/api/bill_exec/make_payment", {
+  fetch("/api/pay_exec/make_payment", {
     method: "POST",
     body: JSON.stringify(data),
     headers: {
@@ -73,7 +98,7 @@ markPaid(data) {
   })
     .then(res => {
       // If "this" is not called in the createBill method, you may have to create the function outside of the class (es-lint rule)
-      this.setState({});
+      this.setPaidStatus(data.payment_id, data.is_paid);
       return res;
     })
     .catch(err => console.log(err));
@@ -81,14 +106,15 @@ markPaid(data) {
 
   componentDidMount() {
     //  actual address http://0.0.0.0:1234/api/bill_data/get_bill
-    fetch("https://jake-good.free.beeceptor.com/my/api/path") // temp
+    fetch("/api/bill_data/get_bills") // temp
       .then(res => {
         return res.json();
       })
       .then(data => {
+        console.log(data.bills);
         // make a mapping of bills to list items here and render it below
         this.setState({
-          bills: data
+          bills: data.bills
         });
       })
       .catch(err => {

--- a/split-webapp/split/src/pages/Transactions.js
+++ b/split-webapp/split/src/pages/Transactions.js
@@ -1,20 +1,20 @@
 import React from "react";
-import SearchIcon from '@material-ui/icons/Search';
+import SearchIcon from "@material-ui/icons/Search";
+import { Divider } from "@material-ui/core";
 import TransactionList from "../components/TransactionList";
-import { Divider } from '@material-ui/core'
-import '../App.css';
+import "../App.css";
 
 function Transactions() {
-        return (
-            <div className="Transactions">
-            <div className="TransactionsTitle">
-                <h1 className="TransactionsText">Transactions </h1>
-                <SearchIcon className="SearchTransactions" />
-                </div>
-                <Divider />
-                <TransactionList />
-            </div>
-        );
+  return (
+    <div className="Transactions">
+      <div className="TransactionsTitle">
+        <h1 className="TransactionsText">Transactions </h1>
+        <SearchIcon className="SearchTransactions" />
+      </div>
+      <Divider />
+      <TransactionList />
+    </div>
+  );
 }
 
 export default Transactions;

--- a/split-webapp/split/src/pages/Transactions.js
+++ b/split-webapp/split/src/pages/Transactions.js
@@ -1,6 +1,7 @@
 import React from "react";
 import SearchIcon from '@material-ui/icons/Search';
 import TransactionList from "../components/TransactionList";
+import { Divider } from '@material-ui/core'
 import '../App.css';
 
 function Transactions() {
@@ -10,6 +11,7 @@ function Transactions() {
                 <h1 className="TransactionsText">Transactions </h1>
                 <SearchIcon className="SearchTransactions" />
                 </div>
+                <Divider />
                 <TransactionList />
             </div>
         );


### PR DESCRIPTION
Closes #43 

**Description**
- Mapped the API call of checkboxes within each payment to its respective API call
- Successfully stores and persists in database so that checkboxes now reflect `is_paid` state
- Styled the transactions box/list
- Update: there is now a default case where a message is printed if no bills are available.

**Testing**

Mostly visual testing for styling, then testing that API call persists by marking payments as paid, switching sites and then coming back. API calls are also successful.

**Checklist**
<!-- this section may be replaced with GitHub action checks later -->
- [x] I have tested my change
- [x] Code builds successfully and all tests pass
- [ ] Docs have been added/updated if needed
