### PR TITLE
Implemented running total on Transactions Page

### DIFF
--- a/split-webapp/split/src/App.css
+++ b/split-webapp/split/src/App.css
@@ -245,7 +245,7 @@
   flex-direction: row;
   display: flex;
   width: 100%;
-  justify-content: flex-start;
+  justify-content: space-between;
 }
 
 .PaymentHeaders {
@@ -259,6 +259,17 @@
   font-size: 20px;
   font-variant-caps: petite-caps;
   align-self: flex-start;
+}
+
+.RunningTotal {
+  flex-direction: row;
+  display: flex;
+}
+
+.Percentage {
+  font-weight: 500;
+  padding-right: 5px;
+  color: #e071ae;
 }
 
 .BillAmount {

--- a/split-webapp/split/src/components/TransactionList.js
+++ b/split-webapp/split/src/components/TransactionList.js
@@ -9,6 +9,17 @@ import {
 import PaymentIcon from "@material-ui/icons/Payment";
 import "../App.css";
 
+function calculateTotalPaid(bill) {
+  let runningTotal = 0;
+  bill.payments.forEach(payment => {
+    if (payment.is_paid) {
+      runningTotal += payment.amount;
+    }
+  });
+
+  return runningTotal;
+}
+
 class TransactionList extends React.Component {
   constructor(props) {
     super(props);
@@ -67,6 +78,14 @@ class TransactionList extends React.Component {
         <ExpansionPanelDetails className="Payments">
           <div className="PaymentsTitle">
             <PaymentIcon className="PaymentHeaders" />
+            <div className="RunningTotal">
+              <div className="BillTitle Percentage">
+                ({Math.round((calculateTotalPaid(bill) / bill.total) * 100)}%){" "}
+              </div>
+              <div className="BillTitle">
+                ${calculateTotalPaid(bill)}/${bill.total}
+              </div>
+            </div>
           </div>
           {bill.payments.map(payment => {
             const label = `${payment.from} owes ${payment.to} $${payment.amount.toFixed(2)}`;

--- a/split-webapp/split/src/components/TransactionList.js
+++ b/split-webapp/split/src/components/TransactionList.js
@@ -20,6 +20,15 @@ function calculateTotalPaid(bill) {
   return runningTotal;
 }
 
+function calculateTotalOutstanding(bill) {
+  let total = 0;
+  bill.payments.forEach(payment => {
+    total += payment.amount;
+  });
+
+  return total;
+}
+
 class TransactionList extends React.Component {
   constructor(props) {
     super(props);
@@ -30,13 +39,11 @@ class TransactionList extends React.Component {
   }
 
   componentDidMount() {
-    //  actual address http://0.0.0.0:1234/api/bill_data/get_bill
     fetch("/api/bill_data/get_bills") // temp
       .then(res => {
         return res.json();
       })
       .then(data => {
-        // make a mapping of bills to list items here and render it below
         this.setState({
           bills: data.bills
         });
@@ -80,10 +87,16 @@ class TransactionList extends React.Component {
             <PaymentIcon className="PaymentHeaders" />
             <div className="RunningTotal">
               <div className="BillTitle Percentage">
-                ({Math.round((calculateTotalPaid(bill) / bill.total) * 100)}%){" "}
+                (
+                {Math.round(
+                  (calculateTotalPaid(bill) / calculateTotalOutstanding(bill)) *
+                    100
+                )}
+                %){" "}
               </div>
               <div className="BillTitle">
-                ${calculateTotalPaid(bill)}/${bill.total}
+                ${calculateTotalPaid(bill).toFixed(2)}/$
+                {calculateTotalOutstanding(bill).toFixed(2)}
               </div>
             </div>
           </div>

--- a/split-webapp/split/src/pages/Transactions.js
+++ b/split-webapp/split/src/pages/Transactions.js
@@ -1,5 +1,5 @@
 import React from "react";
-import SearchIcon from "@material-ui/icons/Search";
+import TollIcon from "@material-ui/icons/Toll";
 import { Divider } from "@material-ui/core";
 import TransactionList from "../components/TransactionList";
 import "../App.css";
@@ -8,8 +8,8 @@ function Transactions() {
   return (
     <div className="Transactions">
       <div className="TransactionsTitle">
-        <h1 className="CardTitle">Transactions </h1>
-        <SearchIcon className="SearchTransactions" />
+        <h1 className="TransactionsText">Transactions </h1>
+        <TollIcon className="SearchTransactions" />
       </div>
       <Divider />
       <TransactionList />


### PR DESCRIPTION
Closes #92 

**Description**

The Transactions page now includes a running total of the payments that *have* been paid, compared to the total amount. A percentage is also added for better visualisation.

Due to no search functionality at the moment, the search icon has also been replaced by coins to avoid misleading capabilities. 

**Testing**

Visual testing and `npm run lint` for ESLint tests.

**Checklist**
<!-- this section may be replaced with GitHub action checks later -->
- [x] I have tested my change
- [x] Code builds successfully and all tests pass
- [ ] Docs have been added/updated if needed
