### PR TITLE
Format payment amount to 2dp

### DIFF
--- a/split-webapp/split/src/components/TransactionList.js
+++ b/split-webapp/split/src/components/TransactionList.js
@@ -61,7 +61,7 @@ class TransactionList extends React.Component {
         <ExpansionPanelSummary>
           <div className="BillSummary">
             <div className="BillTitle">{bill.title}</div>
-            <div className="BillAmount">${bill.total}</div>
+            <div className="BillAmount">${bill.total.toFixed(2)}</div>
           </div>
         </ExpansionPanelSummary>
         <ExpansionPanelDetails className="Payments">
@@ -69,7 +69,7 @@ class TransactionList extends React.Component {
             <PaymentIcon className="PaymentHeaders" />
           </div>
           {bill.payments.map(payment => {
-            const label = `${payment.from} owes ${payment.to} $${payment.amount}`;
+            const label = `${payment.from} owes ${payment.to} $${payment.amount.toFixed(2)}`;
             return (
               <div key={payment.id}>
                 <FormControlLabel


### PR DESCRIPTION
Closes #94

**Description**
* Format bill totals and payment amounts
* Uses `.toFixed(2)` to format numbers representing money to 2 decimal places.

**Testing**
Visually check numbers are rounding correctly. Considered numbers with precision less than and greater than 2 dp as well. See below:
![image](https://user-images.githubusercontent.com/42141786/77019494-91a29500-69e5-11ea-899b-e07e54341ffc.png)


**Checklist**
<!-- this section may be replaced with GitHub action checks later -->
- [x] I have tested my change
- [x] Code builds successfully and all tests pass
- [x] Docs have been added/updated if needed
