### PR TITLE
Changed CherryPy static file routing to use build folder

### DIFF
--- a/server/src/main.py
+++ b/server/src/main.py
@@ -12,23 +12,26 @@ CREATE_TEST_DATA = True
 
 LISTEN_IP = "0.0.0.0"
 LISTEN_PORT = 1234
+SITE_ROOT = os.getenv("SITE_ROOT")
+if SITE_ROOT is None:
+    # if no environment variable has been set, we will assume the server is being used in development
+    SITE_ROOT = "../../split-webapp/split/build"
 
 def run_main_app():
     conf = {
         '/': {
-            'tools.staticdir.root': os.getcwd(),
+            'tools.staticdir.root': os.path.abspath(SITE_ROOT),
+            'tools.staticdir.on': True,
+            'tools.staticdir.dir': '.',
+            'tools.staticdir.index': "index.html",
+
             'tools.encode.on': True,
             'tools.encode.encoding': 'utf-8',
             'tools.sessions.on': True,
-            'tools.sessions.timeout': 60 * 1, #timeout is in minutes, * 60 to get hours
+            'tools.sessions.timeout': 60 * 1, # timeout is in minutes, * 60 to get hours
 
-            # The default session backend is in RAM. Other options are 'file',
-        },
-
-        '/static': {
-            'tools.staticdir.on': True,
-            'tools.staticdir.dir': 'static',
-        },
+            # The default session backend is in RAM. Other options are 'file'
+        }
     }
 
     cherrypy.site = {

--- a/server/src/main.py
+++ b/server/src/main.py
@@ -11,7 +11,9 @@ DB_NAME = "webapp_data.db"
 CREATE_TEST_DATA = True
 
 LISTEN_IP = "0.0.0.0"
-LISTEN_PORT = 1234
+LISTEN_PORT = int(os.getenv("SITE_PORT"))
+if LISTEN_PORT is None:
+    LISTEN_PORT = 1234
 SITE_ROOT = os.getenv("SITE_ROOT")
 if SITE_ROOT is None:
     # if no environment variable has been set, we will assume the server is being used in development

--- a/server/src/server.py
+++ b/server/src/server.py
@@ -2,28 +2,12 @@ import cherrypy
 import urllib.request
 import json
 
-SITE_ROOT = "../../split-webapp/split"
-
 class MainApp(object):
+    """This class would normally handle complex routing.
+    For now, no implementation is needed, as the object constructed from this class will simply
+    be used as a base CherryPy tree.
 
-    _cp_config = {'tools.encode.on': True,
-                  'tools.encode.encoding': 'utf-8',
-                  'tools.sessions.on' : 'True',
-                 }
-
-    @cherrypy.expose
-    def default(self, *args, **kwargs):
-        """The default page, given when we don't recognise where the request is for."""
-        page = open(SITE_ROOT + "/public/index.html", "r")
-        cherrypy.response.status = "404server"
-        return page
-
-    @cherrypy.expose
-    def index(self):
-        """
-        This method serves the client the page
-        Returns:
-            String -- returns a string in html format
-        """
-        page = open(SITE_ROOT + "/public/index.html", "r")
-        return page
+    CherryPy automatically handles differentiating between paths that correspond to files
+    and paths that correspond to API endpoints.
+    """
+    pass


### PR DESCRIPTION
Closes #98 

**Description**

This PR changes the way CherryPy is configured for static file hosting.
`/` now points to a static dir by default. This is setup with `tools.staticdir` similarly to before. 
`SITE_ROOT` is set to the value of an environment variable with the same name, if it exists. Otherwise, it is set to the build folder into which react-scripts puts everything (`split-webapp/split/build`)

CherryPy automatically differentiates between paths that correspond to API requests and paths that correspond to static files, so no extra endpoints need to be implemented in `server.py`

**Testing**

I have built the frontend, run the backend and performed fairly extensive testing of the endpoints with postman, as well as navigating the frontend and ensuring that it makes successful requests to the backend.

**Checklist**
<!-- this section may be replaced with GitHub action checks later -->
- [x] I have tested my change
- [x] Code builds successfully and all tests pass
- [ ] Docs have been added/updated if needed
