### PR TITLE
Split bill correctly accounting for payer

### DIFF
--- a/split-webapp/split/src/pages/Split.js
+++ b/split-webapp/split/src/pages/Split.js
@@ -11,6 +11,7 @@ import {
   FormGroup,
   RadioGroup
 } from "@material-ui/core";
+import PropTypes from "prop-types";
 
 class Split extends Component {
   constructor(props) {
@@ -52,6 +53,7 @@ class Split extends Component {
 
   split() {
     const { transaction } = this.state;
+    const { history } = this.props;
     const usersArray = transaction.users;
     const cost = document.getElementById("cost").value;
     const title = document.getElementById("title").value;
@@ -60,10 +62,12 @@ class Split extends Component {
     const paymentArray = [];
 
     usersArray.forEach(user => {
-      paymentArray.push({
-        person: user,
-        amount: perPersonCost
-      });
+      if (user !== transaction.payed) {
+        paymentArray.push({
+          person: user,
+          amount: perPersonCost
+        });
+      }
     });
 
     const bill = {
@@ -74,6 +78,8 @@ class Split extends Component {
     };
 
     this.createBill(bill);
+
+    history.push("/home/transactions");
   }
 
   createBill(data) {
@@ -167,5 +173,9 @@ class Split extends Component {
     );
   }
 }
+
+Split.propTypes = {
+  history: PropTypes.node.isRequired
+};
 
 export default Split;


### PR DESCRIPTION
Closes #46

**Description**
Splitting logic wasn't fully implemented before.
* Splits bill evenly, does not include showing the payer's own share of the bill only the amount they are owed by others
* Pressing split takes you to the bills page.

**Testing**
* Tested various amounts and number of people into expected user inputs into the create bill form. The number is split evenly and the original payer does not show up as a payment.
* Tested pressing split button takes you to the home page
* It would be nice to have unit tests in the future but the logic is pretty simple and unit tests may be superfluous for now. Maybe if more ways of splitting are added, we should have unit tests for each method. May look into adding unit tests in the future but for now the priority is getting the fix in.

**Checklist**
<!-- this section may be replaced with GitHub action checks later -->
- [x] I have tested my change
- [x] Code builds successfully and all tests pass
- [x] Docs have been added/updated if needed
