### PR TITLE
Fixed main script breaking if no SITE_PORT env-var present

### DIFF
--- a/server/src/main.py
+++ b/server/src/main.py
@@ -11,9 +11,12 @@ DB_NAME = "webapp_data.db"
 CREATE_TEST_DATA = True
 
 LISTEN_IP = "0.0.0.0"
-LISTEN_PORT = int(os.getenv("SITE_PORT"))
+LISTEN_PORT = os.getenv("SITE_PORT")
 if LISTEN_PORT is None:
     LISTEN_PORT = 1234
+else:
+    LISTEN_PORT = int(LISTEN_PORT)
+
 SITE_ROOT = os.getenv("SITE_ROOT")
 if SITE_ROOT is None:
     # if no environment variable has been set, we will assume the server is being used in development


### PR DESCRIPTION
Closes #113 

**Description**

The script gets the server port from an environment variable. It has to convert it to int. The conversion was being performed before checking if it actually existed.

It is now checked for `None` before converting to int

**Testing**

Tested running the server - it works

**Checklist**
<!-- this section may be replaced with GitHub action checks later -->
- [x] I have tested my change
- [x] Code builds successfully and all tests pass
- [x] Docs have been added/updated if needed
