### PR TITLE
Ci cd/backend unit testing

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -1,0 +1,40 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python package
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Lint with flake8
+        continue-on-error: true
+        run: |
+          pip install flake8
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: Test with pytest
+        run: |
+          pip install pytest
+          pytest

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -24,14 +24,12 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install cherrypy
-      - name: Lint with pep8
+      - name: Lint with pycodestyle
         continue-on-error: true
         run: |
-          pip install pep8
+          pip install pycodestyle
           # stop the build if there are Python syntax errors or undefined names
-          pep8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          pep8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+          pycodestyle ./server
       - name: Run unit tests
         run: |
           python3 server/test_db.py

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -4,10 +4,8 @@
 name: Python package
 
 on:
-  push:
-    branches: [master]
   pull_request:
-    branches: [master]
+    paths: server/src/**/*
 
 jobs:
   build:
@@ -25,16 +23,15 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-      - name: Lint with flake8
+          pip install cherrypy
+      - name: Lint with pep8
         continue-on-error: true
         run: |
-          pip install flake8
+          pip install pep8
           # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          pep8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-      - name: Test with pytest
+          pep8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: Run unit tests
         run: |
-          pip install pytest
-          pytest
+          py server/test_db.py

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -34,4 +34,4 @@ jobs:
           pep8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Run unit tests
         run: |
-          py server/test_db.py
+          python3 server/test_db.py


### PR DESCRIPTION
Closes #116 

**Description**

This PR introduces a new workflow that runs unit tests (currently `test_db.py`) on the backend. It includes a step that lints with `pycodestyle` but will not fail if the linting fails.

**Testing**

As usual, I put the workflow on my own master and made a test PR

**Checklist**
<!-- this section may be replaced with GitHub action checks later -->
- [x] I have tested my change
- [x] Code builds successfully and all tests pass
- [x] Docs have been added/updated if needed
