### PR TITLE
Fixed invalid bills getting added (Issue #131)

### DIFF
--- a/split-webapp/split/src/pages/Split.js
+++ b/split-webapp/split/src/pages/Split.js
@@ -86,24 +86,6 @@ class Split extends Component {
 
     const paymentArray = [];
 
-    usersArray.forEach(user => {
-      if (user !== transaction.payed) {
-        paymentArray.push({
-          person: user,
-          amount: perPersonCost
-        });
-      }
-    });
-
-    const bill = {
-      title,
-      payer: transaction.payed,
-      total: cost,
-      outstanding_payments: paymentArray
-    };
-
-    createBill(bill);
-
     if (!title) {
       alert("Please enter a title description for this bill.");
       return;
@@ -122,6 +104,24 @@ class Split extends Component {
       alert("Please choose a payee for this bill.");
       return;
     }
+
+    usersArray.forEach(user => {
+      if (user !== transaction.payed) {
+        paymentArray.push({
+          person: user,
+          amount: perPersonCost
+        });
+      }
+    });
+
+    const bill = {
+      title,
+      payer: transaction.payed,
+      total: cost,
+      outstanding_payments: paymentArray
+    };
+
+    createBill(bill);
 
     history.push("/home/transactions");
   }


### PR DESCRIPTION
Closes #131

**Description**

Fixes the issue where partial bills get added to the database when submitting incomplete bills:
Makes sure it checks whether the information entered is complete *before* creating the entry in the database, and returning if it's invalid.

**Testing**

Tested by attempting to replicate the bug described in the issue and seeing the correct behavior.
Specifically, press "split bill" without the complete information entered. Repeat as you enter information in each field one by one. Once finished, there should only be one entry added.

**Checklist**
<!-- this section may be replaced with GitHub action checks later -->
- [x] I have tested my change
- [ ] Code builds successfully and all tests pass
- [ ] Docs have been added/updated if needed
