### PR TITLE
Polish Split Bills - Part 1 - Restructure split-bills page for new design

### DIFF
--- a/split-webapp/split/.eslintrc
+++ b/split-webapp/split/.eslintrc
@@ -13,6 +13,7 @@
     "prettier/prettier": 0,
     "jsx-a11y/label-has-associated-control": ["error", {
       controlComponents: ["TextField", "CurrencyTextField"],
-    }]
+    }],
+    "no-restricted-syntax": ["error", "ForInStatement", "LabeledStatement", "WithStatement"]
   }
 }

--- a/split-webapp/split/.eslintrc
+++ b/split-webapp/split/.eslintrc
@@ -10,6 +10,9 @@
   "rules": {
     "semi": 1,
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
-    "prettier/prettier": 0
+    "prettier/prettier": 0,
+    'jsx-a11y/label-has-associated-control': ['error', {
+      controlComponents: ['TextField', 'CurrencyTextField'],
+    }]
   }
 }

--- a/split-webapp/split/.eslintrc
+++ b/split-webapp/split/.eslintrc
@@ -11,8 +11,8 @@
     "semi": 1,
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
     "prettier/prettier": 0,
-    'jsx-a11y/label-has-associated-control': ['error', {
-      controlComponents: ['TextField', 'CurrencyTextField'],
+    "jsx-a11y/label-has-associated-control": ["error", {
+      controlComponents: ["TextField", "CurrencyTextField"],
     }]
   }
 }

--- a/split-webapp/split/package-lock.json
+++ b/split-webapp/split/package-lock.json
@@ -1303,6 +1303,30 @@
         "@babel/runtime": "^7.4.4"
       }
     },
+    "@material-ui/lab": {
+      "version": "4.0.0-alpha.49",
+      "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.49.tgz",
+      "integrity": "sha512-Shx+wktDCj7YDlNSkgMeFhijTyqWT0CGn7wDBMck36kZlh3GQhNwaj1y5p219sCYJY44SPgnrDaCxBStlzj8KQ==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/utils": "^4.9.6",
+        "clsx": "^1.0.4",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0"
+      },
+      "dependencies": {
+        "@material-ui/utils": {
+          "version": "4.9.6",
+          "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.9.6.tgz",
+          "integrity": "sha512-gqlBn0JPPTUZeAktn1rgMcy9Iczrr74ecx31tyZLVGdBGGzsxzM6PP6zeS7FuoLS6vG4hoZP7hWnOoHtkR0Kvw==",
+          "requires": {
+            "@babel/runtime": "^7.4.4",
+            "prop-types": "^15.7.2",
+            "react-is": "^16.8.0"
+          }
+        }
+      }
+    },
     "@material-ui/styles": {
       "version": "4.9.0",
       "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.9.0.tgz",
@@ -1936,6 +1960,14 @@
         "tsutils": "^3.17.1"
       }
     },
+    "@unicef/material-ui-currency-textfield": {
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/@unicef/material-ui-currency-textfield/-/material-ui-currency-textfield-0.8.6.tgz",
+      "integrity": "sha512-zXhwJbz8mRa4xVZ6zkkyn9UyXHT4CXFn1JuvkVhDFqtqPkjQXBg+/dWMlJAfX6m1CvwfxwiF9giJxJqFEsTUqg==",
+      "requires": {
+        "autonumeric": "^4.5.4"
+      }
+    },
     "@webassemblyjs/ast": {
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.8.5.tgz",
@@ -2456,6 +2488,11 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
+    },
+    "autonumeric": {
+      "version": "4.5.13",
+      "resolved": "https://registry.npmjs.org/autonumeric/-/autonumeric-4.5.13.tgz",
+      "integrity": "sha512-GHpM0cGWTzFVDQyOgpXlNoqe8fDn6minpGEauLgDnGb4k24WmF8GInLnhIGWoJXisHZuWmTeKqFcIBnf5c2DaA=="
     },
     "autoprefixer": {
       "version": "9.7.4",
@@ -12587,6 +12624,13 @@
         "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
       }
     },
     "request-promise-core": {
@@ -13332,6 +13376,13 @@
       "requires": {
         "faye-websocket": "^0.10.0",
         "uuid": "^3.0.1"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
       }
     },
     "sockjs-client": {
@@ -14483,9 +14534,9 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
     },
     "v8-compile-cache": {
       "version": "2.1.0",
@@ -16076,6 +16127,13 @@
       "requires": {
         "ansi-colors": "^3.0.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
       }
     },
     "webpack-manifest-plugin": {

--- a/split-webapp/split/package.json
+++ b/split-webapp/split/package.json
@@ -6,11 +6,13 @@
   "dependencies": {
     "@material-ui/core": "^4.9.5",
     "@material-ui/icons": "^4.9.1",
+    "@material-ui/lab": "^4.0.0-alpha.48",
     "@material-ui/styles": "^4.9.0",
     "@reduxjs/toolkit": "^1.2.5",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.5.0",
     "@testing-library/user-event": "^7.2.1",
+    "@unicef/material-ui-currency-textfield": "^0.8.6",
     "prop-types": "^15.7.2",
     "react": "^16.13.0",
     "react-dom": "^16.13.0",
@@ -18,7 +20,8 @@
     "react-router-dom": "^5.1.2",
     "react-scripts": "^3.4.0",
     "redux": "^4.0.5",
-    "redux-devtools-extension": "^2.13.8"
+    "redux-devtools-extension": "^2.13.8",
+    "uuid": "^7.0.3"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/split-webapp/split/src/components/EditableBillHeader.js
+++ b/split-webapp/split/src/components/EditableBillHeader.js
@@ -1,0 +1,60 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+import TextField from "@material-ui/core/TextField";
+import EditIcon from "@material-ui/icons/Edit";
+
+import CurrencyTextField from "@unicef/material-ui-currency-textfield";
+
+import FluidInput from "./FluidInput";
+
+import styles from "./EditableBillHeader.module.css";
+
+const EditableBillHeader = ({ title, cost, onTitleChange, onCostChange }) => (
+  <div className={styles.header}>
+    <label className={styles.titleLabel} htmlFor="title">
+      <TextField
+        required
+        id="title"
+        className={styles.titleTextField}
+        placeholder="Untitled Bill"
+        InputProps={{
+          inputComponent: FluidInput
+        }}
+        value={title}
+        onChange={onTitleChange}
+      />
+      <EditIcon className={styles.titleEditIcon} />
+    </label>
+
+    <label className={styles.totalLabel} htmlFor="cost">
+      <span>Total $</span>
+      <CurrencyTextField
+        required
+        id="cost"
+        minimum={0.01}
+        value={cost}
+        placeholder="0.00"
+        onChange={onCostChange}
+        currencySymbol=""
+        InputProps={{
+          inputComponent: FluidInput,
+
+          // We're putting the '$' outside, not inside the textfield.
+          startAdornment: undefined
+        }}
+        className={styles.totalTextField}
+      />
+      <EditIcon className={styles.totalEditIcon} />
+    </label>
+  </div>
+);
+
+EditableBillHeader.propTypes = {
+  title: PropTypes.string.isRequired,
+  cost: PropTypes.number.isRequired,
+  onTitleChange: PropTypes.func.isRequired,
+  onCostChange: PropTypes.func.isRequired
+};
+
+export default EditableBillHeader;

--- a/split-webapp/split/src/components/EditableBillHeader.module.css
+++ b/split-webapp/split/src/components/EditableBillHeader.module.css
@@ -1,0 +1,14 @@
+.header {
+  display: flex;
+}
+
+.titleLabel {
+  flex-grow: 1;
+  margin-right: 30px;
+  text-align: left;
+}
+
+.titleTextField,
+.totalTextField {
+  width: auto;
+}

--- a/split-webapp/split/src/components/EditableBillPeopleList.js
+++ b/split-webapp/split/src/components/EditableBillPeopleList.js
@@ -1,0 +1,76 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+import TextField from "@material-ui/core/TextField";
+import ToggleButton from "@material-ui/lab/ToggleButton";
+import ToggleButtonGroup from "@material-ui/lab/ToggleButtonGroup";
+
+import styles from "./EditableBillPeopleList.module.css";
+
+const PersonRow = ({ person, hasPaid, onTogglePaid, onNameChange }) => (
+  <li>
+    <div className={styles.personRow}>
+      <TextField value={person.name} onChange={onNameChange} fullWidth />
+
+      <ToggleButtonGroup
+        value={hasPaid ? "payee" : "payer"}
+        size="small"
+        exclusive
+        onChange={onTogglePaid}
+      >
+        <ToggleButton value="payer">Payer</ToggleButton>
+        <ToggleButton value="payee">Payee</ToggleButton>
+      </ToggleButtonGroup>
+    </div>
+  </li>
+);
+
+PersonRow.propTypes = {
+  person: PropTypes.shape({
+    name: PropTypes.string.isRequired
+  }).isRequired,
+  hasPaid: PropTypes.bool.isRequired,
+  onTogglePaid: PropTypes.func.isRequired,
+  onNameChange: PropTypes.func.isRequired
+};
+
+const EditableBillPeopleList = ({
+  people,
+  paidPersonId,
+  onPayeeChange,
+  onNameChange
+}) => {
+  return (
+    <ul className={styles.peopleList}>
+      {people.allIds.map(id => (
+        <PersonRow
+          key={id}
+          person={people.byId[id]}
+          hasPaid={id === paidPersonId}
+          onTogglePaid={() => onPayeeChange(id === paidPersonId ? null : id)}
+          onNameChange={event => onNameChange(id, event.target.value)}
+        />
+      ))}
+    </ul>
+  );
+};
+
+EditableBillPeopleList.propTypes = {
+  people: PropTypes.shape({
+    allIds: PropTypes.arrayOf(PropTypes.string.isRequired),
+    byId: PropTypes.objectOf(
+      PropTypes.shape({
+        name: PropTypes.string.isRequired
+      }).isRequired
+    ).isRequired
+  }).isRequired,
+  paidPersonId: PropTypes.string,
+  onPayeeChange: PropTypes.func.isRequired,
+  onNameChange: PropTypes.func.isRequired
+};
+
+EditableBillPeopleList.defaultProps = {
+  paidPersonId: null
+};
+
+export default EditableBillPeopleList;

--- a/split-webapp/split/src/components/EditableBillPeopleList.module.css
+++ b/split-webapp/split/src/components/EditableBillPeopleList.module.css
@@ -1,0 +1,8 @@
+.peopleList {
+  padding: 0;
+  list-style: none;
+}
+
+.personRow {
+  display: flex;
+}

--- a/split-webapp/split/src/components/FluidInput.js
+++ b/split-webapp/split/src/components/FluidInput.js
@@ -1,0 +1,94 @@
+import React, { useState } from "react";
+import PropTypes from "prop-types";
+
+/**
+ * Intended to be used as the internal input component
+ * for material-ui text-fields when you want to
+ * make the text-field automatically adjust its
+ * width based on its contents, rather than having
+ * a fixed width.
+ *
+ * Example usage:
+ *
+ * ```js
+ * <TextField
+ *   className={styles.myTextField}
+ *   InputProps={{
+ *     inputComponent: FluidInput
+ *   }}
+ * />
+ * ```
+ *
+ * ```css
+ * .myTextField {
+ *   width: auto;
+ * }
+ * ```
+ */
+const FluidInput = ({ inputRef, className, placeholder, ...other }) => {
+  const [value, setValue] = useState("");
+
+  // This component uses props spreading so material-ui's
+  // TextField component can pass whatever attribute it needs
+  // to the raw input element.
+  /* eslint-disable react/jsx-props-no-spreading */
+
+  return (
+    <>
+      <input
+        ref={ref => {
+          // Let material-ui know which element is the real input element.
+          inputRef(ref);
+
+          if (ref) {
+            // Initialise any initial value to our fake input span.
+            setValue(ref.value);
+          }
+        }}
+        onInput={event => {
+          // Sync the real input with the fake input span.
+          setValue(event.target.value);
+        }}
+        style={{
+          position: "absolute"
+        }}
+        className={className}
+        placeholder={placeholder}
+        {...other}
+      />
+      {
+        // The following outer span wrapper is to emulate the same
+        // style as the input element so that the size calculation
+        // is accurate.
+      }
+      <span className={className}>
+        {
+          // This inner span is to override the emulated style and make
+          // it invisible.
+        }
+        <span
+          style={{
+            color: "transparent"
+          }}
+        >
+          {value.toString().length ? value : placeholder}
+        </span>
+      </span>
+    </>
+  );
+
+  /* eslint-enable react/jsx-props-no-spreading */
+};
+
+FluidInput.propTypes = {
+  inputRef: PropTypes.func.isRequired,
+  className: PropTypes.string,
+  placeholder: PropTypes.string
+};
+
+FluidInput.defaultProps = {
+  className: "",
+  placeholder: ""
+};
+
+export default FluidInput;

--- a/split-webapp/split/src/pages/Split.js
+++ b/split-webapp/split/src/pages/Split.js
@@ -141,7 +141,7 @@ class Split extends Component {
 
     const uniqueNameSet = new Set();
     for (const userId of users.allIds) {
-      const name = users.byId[userId].name;
+      const { name } = users.byId[userId];
       if (!name) {
         alert("Please enter a name for each person");
         return;

--- a/split-webapp/split/src/pages/Split.js
+++ b/split-webapp/split/src/pages/Split.js
@@ -1,17 +1,15 @@
 import React, { Component } from "react";
-import {
-  Button,
-  ListItem,
-  ListItemText,
-  Divider,
-  TextField,
-  List,
-  FormControlLabel,
-  Radio,
-  FormGroup,
-  RadioGroup
-} from "@material-ui/core";
 import PropTypes from "prop-types";
+
+import Button from "@material-ui/core/Button";
+import AddIcon from "@material-ui/icons/Add";
+
+import { v4 as uuidv4 } from "uuid";
+
+import EditableBillHeader from "../components/EditableBillHeader";
+import EditableBillPeopleList from "../components/EditableBillPeopleList";
+
+import styles from "./Split.module.css";
 
 const createBill = data => {
   fetch("/api/bill_exec/create_bill", {
@@ -31,58 +29,94 @@ class Split extends Component {
   constructor(props) {
     super(props);
 
+    const firstRowId = uuidv4();
+
     this.state = {
       transaction: {
-        title: "title",
-        users: [],
+        title: "",
+        users: {
+          allIds: [firstRowId],
+          byId: {
+            [firstRowId]: { name: "" }
+          }
+        },
         cost: 0,
-        payed: ""
+        payed: null
       }
     };
   }
 
-  addUser() {
+  addUser = () => {
     const { transaction } = this.state;
-    const name = document.getElementById("name").value;
-    document.getElementById("name").value = "";
 
-    if (name.length === 0) {
-      alert("Please enter a valid non-empty name.");
-      return;
-    }
-    if (transaction.users.includes(name)) {
-      alert(
-        "This person is already on the list. Please enter a different name."
-      );
-      return;
-    }
+    const newId = uuidv4();
 
     this.setState({
       transaction: {
         ...transaction,
-        users: transaction.users.concat(name)
+        users: {
+          allIds: [...transaction.users.allIds, newId],
+          byId: {
+            ...transaction.users.byId,
+            [newId]: {
+              name: ""
+            }
+          }
+        }
       }
     });
-  }
+  };
 
-  handleChange(name) {
+  handleNameChange = (userId, newName) => {
     const { transaction } = this.state;
 
     this.setState({
       transaction: {
         ...transaction,
-        payed: name
+        users: {
+          ...transaction.users,
+          byId: {
+            ...transaction.users.byId,
+            [userId]: {
+              ...transaction.users.byId[userId],
+              name: newName
+            }
+          }
+        }
       }
     });
-  }
+  };
 
-  split() {
+  handlePayeeChange = userId => {
+    const { transaction } = this.state;
+
+    this.setState({
+      transaction: { ...transaction, payed: userId }
+    });
+  };
+
+  handleTitleChange = event => {
+    const { transaction } = this.state;
+    const title = event.target.value;
+
+    this.setState({
+      transaction: { ...transaction, title }
+    });
+  };
+
+  handleTotalChange = (event, cost) => {
+    const { transaction } = this.state;
+
+    this.setState({
+      transaction: { ...transaction, cost }
+    });
+  };
+
+  split = () => {
     const { transaction } = this.state;
     const { history } = this.props;
-    const usersArray = transaction.users;
-    const cost = document.getElementById("cost").value;
-    const title = document.getElementById("title").value;
-    const perPersonCost = cost / usersArray.length;
+    const { users, cost, title } = transaction;
+    const perPersonCost = cost / users.allIds.length;
 
     const paymentArray = [];
 
@@ -94,7 +128,7 @@ class Split extends Component {
       alert("Please enter an amount for this bill.");
       return;
     }
-    if (transaction.users.length < 2) {
+    if (transaction.users.allIds.length < 2) {
       alert(
         "There is not enough people to split a bill. Please make sure at least 2 people are on the list."
       );
@@ -105,18 +139,32 @@ class Split extends Component {
       return;
     }
 
-    usersArray.forEach(user => {
-      if (user !== transaction.payed) {
+    const uniqueNameSet = new Set();
+    for (const userId of users.allIds) {
+      const name = users.byId[userId].name;
+      if (!name) {
+        alert("Please enter a name for each person");
+        return;
+      }
+      if (uniqueNameSet.has(name)) {
+        alert("Please enter a different name for each person");
+        return;
+      }
+      uniqueNameSet.add(name);
+    }
+
+    for (const userId of users.allIds) {
+      if (userId !== transaction.payed) {
         paymentArray.push({
-          person: user,
+          person: users.byId[userId].name,
           amount: perPersonCost
         });
       }
-    });
+    }
 
     const bill = {
       title,
-      payer: transaction.payed,
+      payer: transaction.users.byId[transaction.payed].name,
       total: cost,
       outstanding_payments: paymentArray
     };
@@ -124,87 +172,36 @@ class Split extends Component {
     createBill(bill);
 
     history.push("/home/transactions");
-  }
+  };
 
   render() {
     const { transaction } = this.state;
+
     return (
-      <div>
-        <div className="Transactions">
-          <form>
-            <div className="CreateBillHeader">
-              <h1 className="CardTitle">Create a New Payment </h1>
+      <div className={styles.page}>
+        <div className={styles.card}>
+          <EditableBillHeader
+            title={transaction.title}
+            cost={transaction.cost}
+            onTitleChange={this.handleTitleChange}
+            onCostChange={this.handleTotalChange}
+          />
 
-              <TextField
-                required
-                id="title"
-                placeholder="Title"
-                label="Transaction Title"
-              />
-              <div className="SplitLabels">
-                <div className="DollarLabel">$</div>
-                <TextField
-                  required
-                  type="number"
-                  id="cost"
-                  placeholder="45"
-                  label="Amount Paid"
-                />
-              </div>
-            </div>
-            <Divider />
-          </form>
-          <FormGroup>
-            <RadioGroup>
-              {transaction.users.length !== 0 && (
-                <List component="nav" aria-label="main mailbox folders">
-                  {transaction &&
-                    transaction.users.map(user => (
-                      <ListItem button onClick={() => this.handleChange(user)}>
-                        <ListItemText primary={user} />
-                        <FormControlLabel
-                          control={<Radio />}
-                          label="Payee"
-                          checked={user === transaction.payed}
-                        />
-                      </ListItem>
-                    ))}
-                </List>
-              )}
-            </RadioGroup>
-          </FormGroup>
-          <Divider />
-          <div className="BillPayers">
-            <TextField
-              id="name"
-              className="NoEffects"
-              placeholder="Name"
-              type="text"
-              disableUnderline="true"
-              onKeyUp={event => {
-                if (event.key === "Enter") {
-                  this.addUser();
-                }
-              }}
-            />
-            <Button
-              className="AddButton"
-              onClick={() => this.addUser()}
-              variant="contained"
-            >
-              + Add
-            </Button>
-          </div>
+          <EditableBillPeopleList
+            people={transaction.users}
+            paidPersonId={transaction.payed}
+            onPayeeChange={this.handlePayeeChange}
+            onNameChange={this.handleNameChange}
+          />
 
-          <Button
-            className="splitButton"
-            variant="contained"
-            color="primary"
-            onClick={() => this.split()}
-          >
-            Split bill
+          <Button onClick={this.addUser} fullWidth startIcon={<AddIcon />}>
+            Add Person
           </Button>
         </div>
+
+        <Button variant="contained" fullWidth onClick={this.split}>
+          Split This Bill
+        </Button>
       </div>
     );
   }

--- a/split-webapp/split/src/pages/Split.module.css
+++ b/split-webapp/split/src/pages/Split.module.css
@@ -1,0 +1,16 @@
+.page {
+  position: absolute;
+  width: 60%;
+  left: 17%;
+  margin: 100px;
+}
+
+.card {
+  position: relative;
+  margin: 0 0 44px;
+  border-radius: 6px;
+  border: #afc6fd solid 1px;
+  border-radius: 6px;
+  box-shadow: 0 0 6px rgba(0, 0, 0, 0.16);
+  background-color: white;
+}


### PR DESCRIPTION
Part 1 of #129

**Description**

This is the first step into polishing the split-bills page, and it will temporarily look uglier than before.

- Normalize users state using id-based structure
   - This is to help implement drag-n-drop reordering and animations later on.
- Remove the add-user row, and add an add-person button and make every
  row editable
- Remove heading, and make the title text field as the heading.
- Make the title text field and the total-cost text field adjust its
  width based on its contents
   - Introduced a helper `FluidInput.js` component for this.
- Replace radio buttons with toggle buttons
- Move the "Split" button to outside of the card
- Decompose page into smaller components
   - The `Split.js` file is now decomposed into `EditableBillHeader.js` and `EditableBillPeopleList.js` components
- Add minimal styling for overall layout.
- Move old addUser validation to on-submit

Styling, reordering, deleting, and animations will be added in future PRs for this issue.
See #129 for the expected end result after all the PRs for the issue is merged.

**Testing**

Manually Tested:
- Splitting a bill without a title
- Splitting a bill without a total amount
- Splitting a bill without a payee:
   - By not setting a payee
   - By setting a payee and then toggling it back to a payer.
- Splitting a bill with duplicate names
- Splitting a bill with missing names
- Splitting a bill with not enough people to split across
- Clicking on the Total label and the edit icons to focus onto the text fields
- Toggling the payee buttons to ensure that at most one payee is selected at any time.

**Checklist**
<!-- this section may be replaced with GitHub action checks later -->
- [x] I have tested my change
- [x] Code builds successfully and all tests pass
- [x] Docs have been added/updated if needed
