### PR TITLE
Redirect to login page from app when logged out

### DIFF
--- a/split-webapp/split/src/App.js
+++ b/split-webapp/split/src/App.js
@@ -5,6 +5,7 @@ import Home from "./pages/Home";
 import Login from "./pages/Login";
 import SignUp from "./pages/SignUp";
 import { UserProvider } from "./context/UserContext";
+import AuthorizedRoute from "./components/AuthorizedRoute";
 
 function App() {
   return (
@@ -14,7 +15,7 @@ function App() {
           <header className="App-header">
             <div>
               <Route exact path="/" component={Login} />
-              <Route path="/home" component={Home} />
+              <AuthorizedRoute path="/home" component={Home} />
               <Route path="/SignUp" component={SignUp} />
             </div>
           </header>

--- a/split-webapp/split/src/components/AuthorizedRoute.js
+++ b/split-webapp/split/src/components/AuthorizedRoute.js
@@ -1,0 +1,17 @@
+import { Redirect, Route } from "react-router-dom";
+import React, { useContext } from "react";
+import { UserContext } from "../context/UserContext";
+
+const AuthorizedRoute = ({ path, component, exact }) => (
+  <Route
+    path={path}
+    component={
+      useContext(UserContext).username ? component : () => <Redirect to="/" />
+    }
+    exact={exact}
+  />
+);
+
+AuthorizedRoute.propTypes = Route.propTypes;
+
+export default AuthorizedRoute;


### PR DESCRIPTION
Fixes an issue where unauthorized users can access the Split app,
causing errors and undefined behaviour when they try to do things.

Closes #141.

**Description**

Write a simple description of the added feature or solution to the bug.
* Redirect to login page from app when logged out  
* Fixes an issue where unauthorized users can access the Split app,
    causing errors and undefined behaviour when they try to do things.

New files:
* `AuthorizedRoute.js` contains a routing component that which works similarly to `<Route />` but redirects the user if they are not logged in (this is tested by checking if there is an associated username. There might be a more robust test but this does work quite well).

**Testing**

Tried to access various endpoints within the app while logged out. Seems to be working fine.

**Checklist**
<!-- this section may be replaced with GitHub action checks later -->
- [x] I have tested my change
- [x] Code builds successfully and all tests pass
- [ ] Docs have been added/updated if needed